### PR TITLE
Changing share to singleton

### DIFF
--- a/src/Darryldecode/Cart/CartServiceProvider.php
+++ b/src/Darryldecode/Cart/CartServiceProvider.php
@@ -32,7 +32,7 @@ class CartServiceProvider extends ServiceProvider {
 	{
 		$this->mergeConfigFrom(__DIR__.'/config/config.php', 'shopping_cart');
 
-		$this->app['cart'] = $this->app->share(function($app)
+		$this->app->singleton('cart', function($app)
 		{
 			$storage = $app['session'];
 			$events = $app['events'];


### PR DESCRIPTION
With Laravel 5.4 the share method has been deprecated and we have to use the singleton method.